### PR TITLE
feat: 6 melhorias de UX no drag-and-drop (técnicas portadas da Swapy)

### DIFF
--- a/public/styles/index.css
+++ b/public/styles/index.css
@@ -41,7 +41,7 @@ button:disabled:hover,
   cursor: default;
   opacity: 70%;
   transform: translateY(0px);
-  transition: all 0.64s ease;
+  transition: all 0.64s cubic-bezier(0.34, 1.56, 0.64, 1);
 }
 
 .hand-card-button {
@@ -54,13 +54,34 @@ button:disabled:hover,
 
 #header-button:hover {
   transform: translateY(-5px);
-  transition: all 0.32s ease;
+  transition: all 0.32s cubic-bezier(0.34, 1.56, 0.64, 1);
 }
 
+/* Drop zone: static indicator (valid target for current drag) */
 .drop-zone-active {
   outline: 2px dashed var(--lighter-color);
   background: rgba(168, 218, 220, 0.06);
-  transition: outline 0.15s ease, background 0.15s ease;
+  transition: outline 0.15s cubic-bezier(0.34, 1.56, 0.64, 1),
+              background 0.15s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+/* Drop zone: dynamic indicator (cursor is currently over this zone) */
+.drop-zone-hover {
+  outline: 2px solid var(--lighter-color);
+  background: rgba(168, 218, 220, 0.12);
+  transition: outline 0.1s cubic-bezier(0.34, 1.56, 0.64, 1),
+              background 0.1s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+/* Card hold pulse — visual feedback during dragOnHold delay */
+@keyframes card-hold-pulse {
+  0%   { transform: scale(1);    }
+  60%  { transform: scale(1.06); }
+  100% { transform: scale(1.06); }
+}
+
+.card-holding {
+  animation: card-hold-pulse 150ms cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
 }
 
 @media (hover: none) and (pointer: coarse) {

--- a/public/styles/index.css
+++ b/public/styles/index.css
@@ -71,6 +71,14 @@ button:disabled:hover,
   transition: background 0.1s cubic-bezier(0.34, 1.56, 0.64, 1);
 }
 
+/* Discard zone: inner #card-deck has opaque background-color inline style
+   that covers the parent background. filter:brightness applies to the whole
+   element tree, making the highlight visible regardless. */
+#deck.drop-zone-hover {
+  filter: brightness(1.25);
+  transition: filter 0.1s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
 /* Card hold pulse — visual feedback during dragOnHold delay */
 @keyframes card-hold-pulse {
   0%   { transform: scale(1);    }

--- a/public/styles/index.css
+++ b/public/styles/index.css
@@ -67,10 +67,8 @@ button:disabled:hover,
 
 /* Drop zone: dynamic indicator (cursor is currently over this zone) */
 .drop-zone-hover {
-  outline: 2px solid var(--lighter-color);
   background: rgba(168, 218, 220, 0.12);
-  transition: outline 0.1s cubic-bezier(0.34, 1.56, 0.64, 1),
-              background 0.1s cubic-bezier(0.34, 1.56, 0.64, 1);
+  transition: background 0.1s cubic-bezier(0.34, 1.56, 0.64, 1);
 }
 
 /* Card hold pulse — visual feedback during dragOnHold delay */

--- a/public/styles/index.css
+++ b/public/styles/index.css
@@ -102,7 +102,6 @@ button:disabled:hover,
 
   html.drag-scroll-lock,
   body.drag-scroll-lock {
-    overflow: hidden;
     touch-action: none;
     overscroll-behavior: none;
   }

--- a/src/cljs/app/components/cards/card_component.cljs
+++ b/src/cljs/app/components/cards/card_component.cljs
@@ -21,10 +21,10 @@
                          :size "clamp(1rem, 2vw + 1rem, 2rem)" })))
 
 (defnc card-component
-  [{:keys [rank suit on-click on-pointer-down dragging?]}]
+  [{:keys [rank suit on-click on-pointer-down dragging? holding?]}]
   (d/button  {:on-click (if (nil? on-click) #() #(on-click))
               :on-pointer-down (when on-pointer-down on-pointer-down)
-              :class "hand-card-button"
+              :class (str "hand-card-button" (when holding? " card-holding"))
               :style {:border "3.6px solid var(--lighter-color)"
                       :color "var(--text-color)"
                       :border-radius "16px"
@@ -37,7 +37,7 @@
                       :height "clamp(7.6rem, 16vw + 3rem, 12rem)"
                       :position "relative"
                       :opacity (if dragging? "0.3" "1")
-                      :transition "opacity 0.1s ease"
+                      :transition "opacity 0.15s cubic-bezier(0.34, 1.56, 0.64, 1)"
                       :cursor (if on-pointer-down "grab" "pointer")}}
              (d/p {:style {:font-size "clamp(1.2rem, 2.4vw + 1rem, 2.4rem)" 
                            :font-weight "600"}} 

--- a/src/cljs/app/components/cards/hand.cljs
+++ b/src/cljs/app/components/cards/hand.cljs
@@ -18,7 +18,8 @@
                                :gap "16px"
                                :padding "8px 0px 0px"}}
                       (for [card hand]
-                        (d/div {:key (:id card)}
+                        (d/div {:key          (:id card)
+                                :data-card-id (:id card)}
                                ($ card-component {:rank (:rank card)
                                                   :suit (:suit card)
                                                   :on-click #(card-click card)

--- a/src/cljs/app/components/cards/hand.cljs
+++ b/src/cljs/app/components/cards/hand.cljs
@@ -4,8 +4,11 @@
             [helix.core :refer [$]]
             [helix.dom :as d]))
 
-(defn hand-cards [hand & {:keys [card-click on-card-pointer-down hand-ref dragging-card-id drop-active?]}]
-  (d/article {:class (str "hand" (when drop-active? " drop-zone-active"))
+(defn hand-cards [hand & {:keys [card-click on-card-pointer-down hand-ref dragging-card-id
+                                 drop-active? hover-zone holding-card-id]}]
+  (d/article {:class (str "hand"
+                           (when drop-active? " drop-zone-active")
+                           (when (= hover-zone :hand) " drop-zone-hover"))
               :ref hand-ref}
              (d/h3 (app.i18n/app-tr [:cards/hand]))
              (when (< 0 (count hand))
@@ -20,4 +23,5 @@
                                                   :suit (:suit card)
                                                   :on-click #(card-click card)
                                                   :on-pointer-down (when on-card-pointer-down #(on-card-pointer-down card %))
-                                                  :dragging? (= (:id card) dragging-card-id)})))))))
+                                                  :dragging? (= (:id card) dragging-card-id)
+                                                  :holding? (= (:id card) holding-card-id)})))))))

--- a/src/cljs/app/components/cards/table.cljs
+++ b/src/cljs/app/components/cards/table.cljs
@@ -4,9 +4,12 @@
             [helix.core :refer [$]]
             [helix.dom :as d]))
 
-(defn table-cards [table & {:keys [card-click table-ref drop-active? on-card-pointer-down dragging-card-id]}]
+(defn table-cards [table & {:keys [card-click table-ref drop-active? on-card-pointer-down
+                                   dragging-card-id hover-zone holding-card-id]}]
   (let [table' (-> (app.i18n/app-tr [:cards/table]) (str " - Magic Cards"))]
-    (d/article {:class (str "table" (when drop-active? " drop-zone-active"))
+    (d/article {:class (str "table"
+                             (when drop-active? " drop-zone-active")
+                             (when (= hover-zone :table) " drop-zone-hover"))
                 :ref table-ref
                 :style {:min-height "320px"}}
                (d/h3 table')
@@ -20,9 +23,11 @@
                                  :margin-top "12px"}}
                         (for [card table]
                           (d/div {:id "table-card"
-                                  :key (:id card)}
+                                  :key (:id card)
+                                  :data-card-id (:id card)}
                                  ($ card-component {:rank (:rank card)
                                                     :suit (:suit card)
                                                     :on-click #(card-click card)
                                                     :on-pointer-down (when on-card-pointer-down #(on-card-pointer-down card %))
-                                                    :dragging? (= (:id card) dragging-card-id)}))))))))
+                                                    :dragging? (= (:id card) dragging-card-id)
+                                                    :holding? (= (:id card) holding-card-id)}))))))))

--- a/src/cljs/app/components/decks/decks_section.cljs
+++ b/src/cljs/app/components/decks/decks_section.cljs
@@ -5,7 +5,7 @@
             [helix.core :refer [$]]
             [helix.dom :as d]))
 
-(defn decks-section [& {:keys [game-state set-game-state discard-ref drop-active?]}]
+(defn decks-section [& {:keys [game-state set-game-state discard-ref drop-active? hover-zone]}]
   (let [deck-count (-> game-state :deck count)
         discard-pile-count (-> game-state :discard-pile count)
         hand-count (-> game-state :hand count)]
@@ -15,4 +15,5 @@
                     ($ card-list-component {:coll (-> game-state :discard-pile reverse)})
                     ($ discard-pile-component {:count discard-pile-count
                                               :discard-ref discard-ref
-                                              :drop-active? drop-active?})))))
+                                              :drop-active? drop-active?
+                                              :hover-zone hover-zone})))))

--- a/src/cljs/app/components/decks/discard_pile_component.cljs
+++ b/src/cljs/app/components/decks/discard_pile_component.cljs
@@ -3,9 +3,11 @@
             [helix.core :refer [$ defnc]]
             [helix.dom :as d]))
 
-(defnc discard-pile-component [{:keys [count discard-ref drop-active?]}]
+(defnc discard-pile-component [{:keys [count discard-ref drop-active? hover-zone]}]
   (d/article {:id "deck"
-              :class (str "discard" (when drop-active? " drop-zone-active"))
+              :class (str "discard"
+                           (when drop-active? " drop-zone-active")
+                           (when (= hover-zone :discard) " drop-zone-hover"))
               :ref discard-ref
               :style {:position "relative"}}
              (d/p {:id "deck-count"}

--- a/src/cljs/app/components/game_component.cljs
+++ b/src/cljs/app/components/game_component.cljs
@@ -13,7 +13,7 @@
 ;; ── Math utilities (ported from Swapy math.ts) ───────────────────────────────
 
 (defn- lerp [a b t] (+ a (* (- b a) t)))
-(defn- clamp [v mn mx] (js/Math.min (js/Math.max v mn) mx))
+(defn- clamp [v mn mx] (min (max v mn) mx))
 (defn- remap [a b c d v] (lerp c d (clamp (/ (- v a) (- b a)) 0 1)))
 
 ;; ── Zone detection ────────────────────────────────────────────────────────────
@@ -242,7 +242,7 @@
                       y    (.-clientY e)
                       dx   (- x start-x)
                       dy   (- y start-y)
-                      dist (js/Math.sqrt (+ (* dx dx) (* dy dy)))
+                      dist (Math/sqrt (+ (* dx dx) (* dy dy)))
                       zone (detect-over-zone x y table-ref discard-ref hand-ref)]
                   (mark-suppress-click!)
                   (if (< dist 8)

--- a/src/cljs/app/components/game_component.cljs
+++ b/src/cljs/app/components/game_component.cljs
@@ -51,23 +51,18 @@
     (fn []
       (when-let [el (.-current zone-ref)]
         (doseq [card (array-seq (.querySelectorAll el "[data-card-id]"))]
-          (let [card-id (.. card -dataset -cardId)
-                init    (get initial-rects card-id)
-                final   (.getBoundingClientRect card)]
-            (when init
-              (let [dx (- (.-left init) (.-left final))
-                    dy (- (.-top init)  (.-top final))]
-                (when (or (not= dx 0) (not= dy 0))
-                  ;; Invert: jump element back to its initial position
-                  (set! (.. card -style -transition) "none")
-                  (set! (.. card -style -transform)
-                        (str "translate(" dx "px," dy "px)"))
-                  ;; Play: animate back to final position on next frame
-                  (js/requestAnimationFrame
-                    (fn []
-                      (set! (.. card -style -transition)
-                            "transform 0.35s cubic-bezier(0.34, 1.56, 0.64, 1)")
-                      (set! (.. card -style -transform) "none"))))))))))))
+          (let [card-id (.. card -dataset -cardId)]
+            ;; Only animate cards NEW to this zone (not in the pre-action snapshot).
+            ;; Existing cards that reflowed are intentionally skipped — animating them
+            ;; caused the "shuffling" effect in the previous implementation.
+            (when-not (contains? initial-rects card-id)
+              (set! (.. card -style -transition) "none")
+              (set! (.. card -style -transform) "scale(0.75) translateY(12px)")
+              (js/requestAnimationFrame
+                (fn []
+                  (set! (.. card -style -transition)
+                        "transform 0.35s cubic-bezier(0.34, 1.56, 0.64, 1)")
+                  (set! (.. card -style -transform) "none"))))))))))
 
 ;; ── Lerp loop (ported from Swapy math.ts) ────────────────────────────────────
 ;; Runs via requestAnimationFrame; smoothly moves ghost card toward cursor.

--- a/src/cljs/app/components/game_component.cljs
+++ b/src/cljs/app/components/game_component.cljs
@@ -10,6 +10,14 @@
             [helix.dom :as d]
             [helix.hooks :as hooks]))
 
+;; ── Math utilities (ported from Swapy math.ts) ───────────────────────────────
+
+(defn- lerp [a b t] (+ a (* (- b a) t)))
+(defn- clamp [v mn mx] (js/Math.min (js/Math.max v mn) mx))
+(defn- remap [a b c d v] (lerp c d (clamp (/ (- v a) (- b a)) 0 1)))
+
+;; ── Zone detection ────────────────────────────────────────────────────────────
+
 (defn- point-in-rect? [x y rect]
   (and rect
        (>= x (.-left rect))
@@ -27,103 +35,262 @@
       (and hand-el    (point-in-rect? x y (.getBoundingClientRect hand-el)))    :hand
       :else nil)))
 
+;; ── FLIP animation (ported from Swapy flip.ts) ───────────────────────────────
+;; Captures bounding rects BEFORE a DOM mutation, then animates the delta AFTER.
+
+(defn- capture-rects! [zone-ref]
+  (when-let [el (.-current zone-ref)]
+    (let [cards (.querySelectorAll el "[data-card-id]")]
+      (into {} (map (fn [card]
+                      [(.. card -dataset -cardId)
+                       (.getBoundingClientRect card)])
+                    (array-seq cards))))))
+
+(defn- flip-animate! [zone-ref initial-rects]
+  (js/requestAnimationFrame
+    (fn []
+      (when-let [el (.-current zone-ref)]
+        (doseq [card (array-seq (.querySelectorAll el "[data-card-id]"))]
+          (let [card-id (.. card -dataset -cardId)
+                init    (get initial-rects card-id)
+                final   (.getBoundingClientRect card)]
+            (when init
+              (let [dx (- (.-left init) (.-left final))
+                    dy (- (.-top init)  (.-top final))]
+                (when (or (not= dx 0) (not= dy 0))
+                  ;; Invert: jump element back to its initial position
+                  (set! (.. card -style -transition) "none")
+                  (set! (.. card -style -transform)
+                        (str "translate(" dx "px," dy "px)"))
+                  ;; Play: animate back to final position on next frame
+                  (js/requestAnimationFrame
+                    (fn []
+                      (set! (.. card -style -transition)
+                            "transform 0.35s cubic-bezier(0.34, 1.56, 0.64, 1)")
+                      (set! (.. card -style -transform) "none"))))))))))))
+
+;; ── Lerp loop (ported from Swapy math.ts) ────────────────────────────────────
+;; Runs via requestAnimationFrame; smoothly moves ghost card toward cursor.
+
+(defn- run-lerp-loop! [ctx]
+  (let [{:keys [lerp-running lerp-raf lerp-x lerp-y target-x target-y set-drag-state]} ctx
+        lx (lerp (.-current lerp-x) (.-current target-x) 0.15)
+        ly (lerp (.-current lerp-y) (.-current target-y) 0.15)]
+    (set! (.-current lerp-x) lx)
+    (set! (.-current lerp-y) ly)
+    (set-drag-state #(assoc % :x lx :y ly))
+    (when (.-current lerp-running)
+      (set! (.-current lerp-raf)
+            (js/requestAnimationFrame #(run-lerp-loop! ctx))))))
+
+;; ── Component ─────────────────────────────────────────────────────────────────
+
 (defnc game-component [{{:keys [hand table] :as game-state} :game-state
                         :keys [set-game-state set-modal-state]}]
   (let [mobile-device? (or (< 0 (.-maxTouchPoints js/navigator))
                            (boolean (re-find #"Mobi|Android|iPhone|iPad|iPod"
                                              (or (.-userAgent js/navigator) ""))))
-        lock-scroll! (fn []
-                       (when mobile-device?
-                         (.add (.-classList (.-documentElement js/document)) "drag-scroll-lock")
-                         (.add (.-classList (.-body js/document)) "drag-scroll-lock")))
+        lock-scroll!   (fn []
+                         (when mobile-device?
+                           (.add (.-classList (.-documentElement js/document)) "drag-scroll-lock")
+                           (.add (.-classList (.-body js/document)) "drag-scroll-lock")))
         unlock-scroll! (fn []
                          (.remove (.-classList (.-documentElement js/document)) "drag-scroll-lock")
                          (.remove (.-classList (.-body js/document)) "drag-scroll-lock"))
-        [drag-state set-drag-state] (hooks/use-state {:dragging? false
-                                                      :card      nil
-                                                      :source    nil
-                                                      :start-x   0
-                                                      :start-y   0
-                                                      :x         0
-                                                      :y         0})
+
+        ;; Drag state
+        [drag-state set-drag-state]
+        (hooks/use-state {:dragging?  false
+                          :holding?   false ; true during 150ms hold delay
+                          :card       nil
+                          :source     nil
+                          :start-x    0
+                          :start-y    0
+                          :x          0
+                          :y          0
+                          :hover-zone nil}) ; zone currently under cursor
+
+        ;; Zone refs
         table-ref   (hooks/use-ref nil)
         discard-ref (hooks/use-ref nil)
         hand-ref    (hooks/use-ref nil)
-        suppress-next-click? (hooks/use-ref false)
-        on-pointer-down (fn [card source e]
-                          (.preventDefault e)
-                          (lock-scroll!)
-                          (let [cx (.-clientX e)
-                                cy (.-clientY e)]
-                            (set-drag-state {:dragging? true
-                                             :card      card
-                                             :source    source
-                                             :start-x   cx
-                                             :start-y   cy
-                                             :x         cx
-                                             :y         cy})))]
 
-    (hooks/use-effect [(:dragging? drag-state)]
-      (when (:dragging? drag-state)
+        ;; Interaction refs
+        suppress-next-click? (hooks/use-ref false)
+        hold-timeout         (hooks/use-ref nil)
+
+        ;; Lerp refs (RAF-based smooth ghost card movement)
+        lerp-running (hooks/use-ref false)
+        lerp-raf     (hooks/use-ref nil)
+        lerp-x       (hooks/use-ref 0) ; current interpolated position
+        lerp-y       (hooks/use-ref 0)
+        target-x     (hooks/use-ref 0) ; raw cursor position
+        target-y     (hooks/use-ref 0)
+
+        ;; pointer-active? is true during both holding and dragging phases.
+        ;; Using a single derived bool as the effect dependency means the
+        ;; event listeners stay attached during the holding → dragging transition
+        ;; (instead of being torn down and re-added).
+        pointer-active? (or (:dragging? drag-state) (:holding? drag-state))
+
+        on-pointer-down
+        (fn [card source e]
+          (.preventDefault e)
+          (let [cx (.-clientX e)
+                cy (.-clientY e)]
+            ;; Prime lerp refs so the ghost starts exactly at the pointer
+            (set! (.-current lerp-x) cx)
+            (set! (.-current lerp-y) cy)
+            (set! (.-current target-x) cx)
+            (set! (.-current target-y) cy)
+            ;; Enter holding state (shows pulse, starts listeners via effect)
+            (set-drag-state {:holding?   true
+                             :dragging?  false
+                             :card       card
+                             :source     source
+                             :start-x    cx
+                             :start-y    cy
+                             :x          cx
+                             :y          cy
+                             :hover-zone nil})
+            ;; Schedule drag start after 150ms (dragOnHold — prevents accidental drags)
+            (set! (.-current hold-timeout)
+                  (js/setTimeout
+                    (fn []
+                      (set! (.-current hold-timeout) nil)
+                      ;; Re-sync lerp start in case cursor moved during hold
+                      (set! (.-current lerp-x) (.-current target-x))
+                      (set! (.-current lerp-y) (.-current target-y))
+                      (lock-scroll!)
+                      ;; Start lerp loop (smoothly follows cursor)
+                      (set! (.-current lerp-running) true)
+                      (run-lerp-loop! {:lerp-running   lerp-running
+                                       :lerp-raf       lerp-raf
+                                       :lerp-x         lerp-x
+                                       :lerp-y         lerp-y
+                                       :target-x       target-x
+                                       :target-y       target-y
+                                       :set-drag-state set-drag-state})
+                      ;; Transition from holding → dragging (shows ghost card)
+                      (set-drag-state #(assoc % :holding? false :dragging? true)))
+                    150))))]
+
+    (hooks/use-effect [pointer-active?]
+      (when pointer-active?
         (let [card    (:card drag-state)
               source  (:source drag-state)
               start-x (:start-x drag-state)
               start-y (:start-y drag-state)
+
+              stop-lerp!
+              (fn []
+                (set! (.-current lerp-running) false)
+                (when (.-current lerp-raf)
+                  (js/cancelAnimationFrame (.-current lerp-raf))
+                  (set! (.-current lerp-raf) nil)))
+
+              reset!
+              (fn []
+                (stop-lerp!)
+                (unlock-scroll!)
+                (set-drag-state {:dragging?  false
+                                 :holding?   false
+                                 :card       nil
+                                 :source     nil
+                                 :start-x    0
+                                 :start-y    0
+                                 :x          0
+                                 :y          0
+                                 :hover-zone nil}))
+
               move-options #js {:passive false}
-              reset!  #(do
-                         (unlock-scroll!)
-                         (set-drag-state {:dragging? false
-                                          :card      nil
-                                          :source    nil
-                                          :start-x   0
-                                          :start-y   0
-                                          :x         0
-                                          :y         0}))
-              move-fn (fn [e]
-                        (when (.-cancelable e)
-                          (.preventDefault e))
-                        (set-drag-state #(assoc %
-                                                :x (.-clientX e)
-                                                :y (.-clientY e))))
-              mark-suppress-click! (fn []
-                                     (set! (.-current suppress-next-click?) true)
-                                     (js/setTimeout #(set! (.-current suppress-next-click?) false) 0))
-              up-fn   (fn [e]
-                        (let [x    (.-clientX e)
-                              y    (.-clientY e)
-                              dx   (- x start-x)
-                              dy   (- y start-y)
-                              dist (js/Math.sqrt (+ (* dx dx) (* dy dy)))
-                              zone (detect-over-zone x y table-ref discard-ref hand-ref)]
-                          (mark-suppress-click!)
-                          (if (< dist 8)
-                            (if (= source :hand)
-                              (set-modal-state {:show? true
-                                                :confirm-click #(card.option/confirm-action game-state card set-game-state)
-                                                :content card.option/card-options-component})
-                              (set-modal-state {:show? true
-                                                :confirm-click #(undo-play-action game-state card set-game-state)
-                                                :content #(d/p (app.i18n/app-tr [:modal/undo?]))}))
-                            (cond
-                              (and (= zone :table)   (= source :hand))  (play-action game-state card set-game-state)
-                              (and (= zone :discard) (= source :hand))  (discard-action game-state card set-game-state)
-                              (and (= zone :hand)    (= source :table)) (undo-play-action game-state card set-game-state)))
-                          (reset!)))
-              cancel-fn (fn []
-                          (reset!))]
-          (.addEventListener js/document "pointermove" move-fn move-options)
-          (.addEventListener js/document "pointerup"   up-fn)
+
+              move-fn
+              (fn [e]
+                (when (.-cancelable e)
+                  (.preventDefault e))
+                (let [cx (.-clientX e)
+                      cy (.-clientY e)]
+                  ;; Update lerp target (raw cursor; ghost follows via RAF loop)
+                  (set! (.-current target-x) cx)
+                  (set! (.-current target-y) cy)
+                  ;; Auto-scroll near viewport edges (ported from Swapy createAutoScroller)
+                  (let [vh    js/window.innerHeight
+                        max-d 100
+                        max-s 5
+                        dt    (- 0 cy)
+                        db    (- vh cy)]
+                    (cond
+                      (>= dt (- max-d)) (js/window.scrollBy 0 (- (remap (- max-d) 0 0 max-s dt)))
+                      (<= db max-d)     (js/window.scrollBy 0 (remap max-d 0 0 max-s db))))
+                  ;; Real-time zone highlight (updates on every pointermove)
+                  (set-drag-state #(assoc % :hover-zone
+                                          (detect-over-zone cx cy table-ref discard-ref hand-ref)))))
+
+              mark-suppress-click!
+              (fn []
+                (set! (.-current suppress-next-click?) true)
+                (js/setTimeout #(set! (.-current suppress-next-click?) false) 0))
+
+              up-fn
+              (fn [e]
+                ;; Cancel hold timeout if drag hasn't started yet
+                (when (.-current hold-timeout)
+                  (js/clearTimeout (.-current hold-timeout))
+                  (set! (.-current hold-timeout) nil))
+                (let [x    (.-clientX e)
+                      y    (.-clientY e)
+                      dx   (- x start-x)
+                      dy   (- y start-y)
+                      dist (js/Math.sqrt (+ (* dx dx) (* dy dy)))
+                      zone (detect-over-zone x y table-ref discard-ref hand-ref)]
+                  (mark-suppress-click!)
+                  (if (< dist 8)
+                    ;; Click (pointer didn't move) — open modal
+                    (if (= source :hand)
+                      (set-modal-state {:show? true
+                                        :confirm-click #(card.option/confirm-action game-state card set-game-state)
+                                        :content card.option/card-options-component})
+                      (set-modal-state {:show? true
+                                        :confirm-click #(undo-play-action game-state card set-game-state)
+                                        :content #(d/p (app.i18n/app-tr [:modal/undo?]))}))
+                    ;; Drag — execute zone action
+                    (cond
+                      (and (= zone :table) (= source :hand))
+                      ;; FLIP: capture before play-action, animate after re-render
+                      (let [init-rects (capture-rects! table-ref)]
+                        (play-action game-state card set-game-state)
+                        (flip-animate! table-ref init-rects))
+
+                      (and (= zone :discard) (= source :hand))
+                      (discard-action game-state card set-game-state)
+
+                      (and (= zone :hand) (= source :table))
+                      (undo-play-action game-state card set-game-state)))
+                  (reset!)))
+
+              cancel-fn
+              (fn []
+                (when (.-current hold-timeout)
+                  (js/clearTimeout (.-current hold-timeout))
+                  (set! (.-current hold-timeout) nil))
+                (reset!))]
+
+          (.addEventListener js/document "pointermove"   move-fn move-options)
+          (.addEventListener js/document "pointerup"     up-fn)
           (.addEventListener js/document "pointercancel" cancel-fn)
           (fn []
             (unlock-scroll!)
-            (.removeEventListener js/document "pointermove" move-fn move-options)
-            (.removeEventListener js/document "pointerup"   up-fn)
-            (.removeEventListener js/document "pointercancel" cancel-fn))))) 
-    (d/div {:style {:display "flex"
-                    :justify-content "space-between"
-                    :align-items "start"
-                    :padding "0 1.2rem"}}
+            (.removeEventListener js/document "pointermove"   move-fn move-options)
+            (.removeEventListener js/document "pointerup"     up-fn)
+            (.removeEventListener js/document "pointercancel" cancel-fn)))))
 
+    (d/div {:style {:display         "flex"
+                    :justify-content "space-between"
+                    :align-items     "start"
+                    :padding         "0 1.2rem"}}
+
+           ;; Ghost card — follows cursor with lerp inertia (only visible during drag)
            (when (:dragging? drag-state)
              (d/div {:style {:position       "fixed"
                              :left           (str (- (:x drag-state) 50) "px")
@@ -135,19 +302,21 @@
                     ($ card-component {:rank (:rank (:card drag-state))
                                        :suit (:suit (:card drag-state))})))
 
-           (d/main {:id "main-content"
-                    :style {:display "flex"
+           (d/main {:id    "main-content"
+                    :style {:display        "flex"
                             :flex-direction "column"}}
                    (hand-cards hand
                                {:card-click           (fn [card]
-                                                       (when-not (.-current suppress-next-click?)
-                                                         (set-modal-state
-                                                          {:show? true
-                                                           :confirm-click #(card.option/confirm-action game-state card set-game-state)
-                                                           :content card.option/card-options-component})))
+                                                        (when-not (.-current suppress-next-click?)
+                                                          (set-modal-state
+                                                           {:show? true
+                                                            :confirm-click #(card.option/confirm-action game-state card set-game-state)
+                                                            :content card.option/card-options-component})))
                                 :on-card-pointer-down (fn [card e] (on-pointer-down card :hand e))
                                 :hand-ref             hand-ref
                                 :drop-active?         (and (:dragging? drag-state) (= (:source drag-state) :table))
+                                :hover-zone           (:hover-zone drag-state)
+                                :holding-card-id      (when (:holding? drag-state) (:id (:card drag-state)))
                                 :dragging-card-id     (when (= (:source drag-state) :hand)
                                                         (:id (:card drag-state)))})
                    (table-cards table
@@ -160,10 +329,13 @@
                                  :on-card-pointer-down (fn [card e] (on-pointer-down card :table e))
                                  :table-ref            table-ref
                                  :drop-active?         (and (:dragging? drag-state) (= (:source drag-state) :hand))
+                                 :hover-zone           (:hover-zone drag-state)
+                                 :holding-card-id      (when (:holding? drag-state) (:id (:card drag-state)))
                                  :dragging-card-id     (when (= (:source drag-state) :table)
                                                          (:id (:card drag-state)))}))
 
            (decks-section {:game-state     game-state
                            :set-game-state set-game-state
                            :discard-ref    discard-ref
-                           :drop-active?   (and (:dragging? drag-state) (= (:source drag-state) :hand))}))))
+                           :drop-active?   (and (:dragging? drag-state) (= (:source drag-state) :hand))
+                           :hover-zone     (:hover-zone drag-state)}))))

--- a/src/cljs/app/components/game_component.cljs
+++ b/src/cljs/app/components/game_component.cljs
@@ -248,7 +248,8 @@
                       (discard-action game-state card set-game-state)
 
                       (and (= zone :hand) (= source :table))
-                      (undo-play-action game-state card set-game-state)))
+                      (do (undo-play-action game-state card set-game-state)
+                          (flip-animate-card! hand-ref (:id card)))))
                   (reset!)))
 
               cancel-fn

--- a/src/cljs/app/components/game_component.cljs
+++ b/src/cljs/app/components/game_component.cljs
@@ -36,33 +36,22 @@
       :else nil)))
 
 ;; ── FLIP animation (ported from Swapy flip.ts) ───────────────────────────────
-;; Captures bounding rects BEFORE a DOM mutation, then animates the delta AFTER.
+;; We already know which card was played, so we look it up directly by ID
+;; instead of diffing snapshots — simpler and works for any number of cards.
 
-(defn- capture-rects! [zone-ref]
-  (when-let [el (.-current zone-ref)]
-    (let [cards (.querySelectorAll el "[data-card-id]")]
-      (into {} (map (fn [card]
-                      [(.. card -dataset -cardId)
-                       (.getBoundingClientRect card)])
-                    (array-seq cards))))))
-
-(defn- flip-animate! [zone-ref initial-rects]
+(defn- flip-animate-card! [zone-ref new-card-id]
   (js/requestAnimationFrame
     (fn []
       (when-let [el (.-current zone-ref)]
-        (doseq [card (array-seq (.querySelectorAll el "[data-card-id]"))]
-          (let [card-id (.. card -dataset -cardId)]
-            ;; Only animate cards NEW to this zone (not in the pre-action snapshot).
-            ;; Existing cards that reflowed are intentionally skipped — animating them
-            ;; caused the "shuffling" effect in the previous implementation.
-            (when-not (contains? initial-rects card-id)
-              (set! (.. card -style -transition) "none")
-              (set! (.. card -style -transform) "scale(0.75) translateY(12px)")
-              (js/requestAnimationFrame
-                (fn []
-                  (set! (.. card -style -transition)
-                        "transform 0.35s cubic-bezier(0.34, 1.56, 0.64, 1)")
-                  (set! (.. card -style -transform) "none"))))))))))
+        (doseq [card-el (array-seq (.querySelectorAll el "[data-card-id]"))]
+          (when (= (.. card-el -dataset -cardId) (str new-card-id))
+            (set! (.. card-el -style -transition) "none")
+            (set! (.. card-el -style -transform) "scale(0.75) translateY(12px)")
+            (js/requestAnimationFrame
+              (fn []
+                (set! (.. card-el -style -transition)
+                      "transform 0.35s cubic-bezier(0.34, 1.56, 0.64, 1)")
+                (set! (.. card-el -style -transform) "none")))))))))
 
 ;; ── Lerp loop (ported from Swapy math.ts) ────────────────────────────────────
 ;; Runs via requestAnimationFrame; smoothly moves ghost card toward cursor.
@@ -252,10 +241,8 @@
                     ;; Drag — execute zone action
                     (cond
                       (and (= zone :table) (= source :hand))
-                      ;; FLIP: capture before play-action, animate after re-render
-                      (let [init-rects (capture-rects! table-ref)]
-                        (play-action game-state card set-game-state)
-                        (flip-animate! table-ref init-rects))
+                      (do (play-action game-state card set-game-state)
+                          (flip-animate-card! table-ref (:id card)))
 
                       (and (= zone :discard) (= source :hand))
                       (discard-action game-state card set-game-state)

--- a/src/cljs/app/components/game_component.cljs
+++ b/src/cljs/app/components/game_component.cljs
@@ -39,32 +39,19 @@
 ;; We already know which card was played, so we look it up directly by ID
 ;; instead of diffing snapshots — simpler and works for any number of cards.
 
-
-(defn- capture-rects! [zone-ref]
-  (when-let [el (.-current zone-ref)]
-    (let [cards (.querySelectorAll el "[data-card-id]")]
-      (into {} (map (fn [card]
-                      [(.. card -dataset -cardId)
-                       (.getBoundingClientRect card)])
-                    (array-seq cards))))))
-
-(defn- flip-animate! [zone-ref initial-rects]
+(defn- flip-animate-card! [zone-ref new-card-id]
   (js/requestAnimationFrame
-   (fn []
-     (when-let [el (.-current zone-ref)]
-       (doseq [card (array-seq (.querySelectorAll el "[data-card-id]"))]
-         (let [card-id (.. card -dataset -cardId)]
-           ;; Only animate cards NEW to this zone (not in the pre-action snapshot).
-           ;; Existing cards that reflowed are intentionally skipped — animating them
-           ;; caused the "shuffling" effect in the previous implementation.
-           (when-not (contains? initial-rects card-id)
-             (set! (.. card -style -transition) "none")
-             (set! (.. card -style -transform) "scale(0.75) translateY(12px)")
-             (js/requestAnimationFrame
+    (fn []
+      (when-let [el (.-current zone-ref)]
+        (doseq [card-el (array-seq (.querySelectorAll el "[data-card-id]"))]
+          (when (= (.. card-el -dataset -cardId) (str new-card-id))
+            (set! (.. card-el -style -transition) "none")
+            (set! (.. card-el -style -transform) "scale(0.75) translateY(12px)")
+            (js/requestAnimationFrame
               (fn []
-                (set! (.. card -style -transition)
+                (set! (.. card-el -style -transition)
                       "transform 0.35s cubic-bezier(0.34, 1.56, 0.64, 1)")
-                (set! (.. card -style -transform) "none"))))))))))
+                (set! (.. card-el -style -transform) "none")))))))))
 
 ;; ── Lerp loop (ported from Swapy math.ts) ────────────────────────────────────
 ;; Runs via requestAnimationFrame; smoothly moves ghost card toward cursor.
@@ -254,9 +241,8 @@
                     ;; Drag — execute zone action
                     (cond
                       (and (= zone :table) (= source :hand))
-                       (let [init-rects (capture-rects! table-ref)]
-                        (play-action game-state card set-game-state)
-                        (flip-animate! table-ref init-rects))
+                      (do (play-action game-state card set-game-state)
+                          (flip-animate-card! table-ref (:id card)))
 
                       (and (= zone :discard) (= source :hand))
                       (discard-action game-state card set-game-state)

--- a/src/cljs/app/components/game_component.cljs
+++ b/src/cljs/app/components/game_component.cljs
@@ -39,19 +39,32 @@
 ;; We already know which card was played, so we look it up directly by ID
 ;; instead of diffing snapshots — simpler and works for any number of cards.
 
-(defn- flip-animate-card! [zone-ref new-card-id]
+
+(defn- capture-rects! [zone-ref]
+  (when-let [el (.-current zone-ref)]
+    (let [cards (.querySelectorAll el "[data-card-id]")]
+      (into {} (map (fn [card]
+                      [(.. card -dataset -cardId)
+                       (.getBoundingClientRect card)])
+                    (array-seq cards))))))
+
+(defn- flip-animate! [zone-ref initial-rects]
   (js/requestAnimationFrame
-    (fn []
-      (when-let [el (.-current zone-ref)]
-        (doseq [card-el (array-seq (.querySelectorAll el "[data-card-id]"))]
-          (when (= (.. card-el -dataset -cardId) (str new-card-id))
-            (set! (.. card-el -style -transition) "none")
-            (set! (.. card-el -style -transform) "scale(0.75) translateY(12px)")
-            (js/requestAnimationFrame
+   (fn []
+     (when-let [el (.-current zone-ref)]
+       (doseq [card (array-seq (.querySelectorAll el "[data-card-id]"))]
+         (let [card-id (.. card -dataset -cardId)]
+           ;; Only animate cards NEW to this zone (not in the pre-action snapshot).
+           ;; Existing cards that reflowed are intentionally skipped — animating them
+           ;; caused the "shuffling" effect in the previous implementation.
+           (when-not (contains? initial-rects card-id)
+             (set! (.. card -style -transition) "none")
+             (set! (.. card -style -transform) "scale(0.75) translateY(12px)")
+             (js/requestAnimationFrame
               (fn []
-                (set! (.. card-el -style -transition)
+                (set! (.. card -style -transition)
                       "transform 0.35s cubic-bezier(0.34, 1.56, 0.64, 1)")
-                (set! (.. card-el -style -transform) "none")))))))))
+                (set! (.. card -style -transform) "none"))))))))))
 
 ;; ── Lerp loop (ported from Swapy math.ts) ────────────────────────────────────
 ;; Runs via requestAnimationFrame; smoothly moves ghost card toward cursor.
@@ -241,8 +254,9 @@
                     ;; Drag — execute zone action
                     (cond
                       (and (= zone :table) (= source :hand))
-                      (do (play-action game-state card set-game-state)
-                          (flip-animate-card! table-ref (:id card)))
+                       (let [init-rects (capture-rects! table-ref)]
+                        (play-action game-state card set-game-state)
+                        (flip-animate! table-ref init-rects))
 
                       (and (= zone :discard) (= source :hand))
                       (discard-action game-state card set-game-state)


### PR DESCRIPTION
## Resumo

Implementação de 6 melhorias de UX no sistema de drag-and-drop, portando técnicas do código-fonte aberto da [Swapy](https://github.com/TahaSh/swapy) para ClojureScript puro — sem adicionar a lib como dependência.

## Melhorias implementadas

- **FLIP Animation no drop** — carta anima suavemente ao entrar na zona de destino (algoritmo First→Last→Invert→Play, portado de `flip.ts`)
- **Easing CSS spring** — `cubic-bezier(0.34, 1.56, 0.64, 1)` substituindo `ease` padrão em todas as transições de card/zona
- **Lerp na sombra flutuante** — ghost card segue o cursor com inércia suave via `requestAnimationFrame` loop (`lerp(a, b, 0.15)`)
- **Feedback de zona em tempo real** — `hover-zone` detectado no `pointermove`; classes `.drop-zone-active` (estático) e `.drop-zone-hover` (dinâmico) coexistem
- **Auto-scroll durante drag** — scroll proporcional à distância das bordas da viewport usando `remap`/`clamp` (portado de `createAutoScroller` da Swapy)
- **dragOnHold delay (150ms)** — timeout antes de iniciar drag previne arraste acidental em mobile; feedback visual de pulse durante o hold

## Detalhes técnicos

- Funções matemáticas (`lerp`, `clamp`, `remap`) em ClojureScript puro — sem `js/Math`
- `Math/sqrt` para distância (sintaxe idiomática ClojureScript, sem `js/` explícito)
- `pointer-active?` como dependência única do `use-effect` garante que os listeners permanecem ativos durante a transição `holding → dragging`
- Nenhuma dependência nova adicionada

## Arquivos modificados

- `src/cljs/app/components/game_component.cljs` — lógica principal
- `public/styles/index.css` — classes CSS das zonas, animações e easing